### PR TITLE
Make package TYPO3 version independent

### DIFF
--- a/Classes/Contract/PaginationInterface.php
+++ b/Classes/Contract/PaginationInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GeorgRinger\NumberedPagination\Contract;
+
+interface PaginationInterface
+{
+    public function __construct(PaginatorInterface $paginator);
+
+    public function getPreviousPageNumber(): ?int;
+
+    public function getNextPageNumber(): ?int;
+
+    public function getFirstPageNumber(): int;
+
+    public function getLastPageNumber(): int;
+
+    public function getStartRecordNumber(): int;
+
+    public function getEndRecordNumber(): int;
+}

--- a/Classes/Contract/PaginatorInterface.php
+++ b/Classes/Contract/PaginatorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GeorgRinger\NumberedPagination\Contract;
+
+interface PaginatorInterface
+{
+    public function withItemsPerPage(int $itemsPerPage): PaginatorInterface;
+
+    public function withCurrentPageNumber(int $currentPageNumber): PaginatorInterface;
+
+    public function getPaginatedItems(): iterable;
+
+    public function getNumberOfPages(): int;
+
+    public function getCurrentPageNumber(): int;
+
+    public function getKeyOfFirstPaginatedItem(): int;
+
+    public function getKeyOfLastPaginatedItem(): int;
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "georgringer/numbered-pagination",
 	"type": "typo3-cms-extension",
-	"description": "Improved pagination for TYPO3 10+",
+	"description": "Improved pagination for TYPO3",
 	"keywords": [
 		"TYPO3",
 		"pagination"
@@ -15,7 +15,7 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"typo3/cms-core": "^10 || ^11",
+		"typo3/cms-core": "^9 || ^10 || ^11",
 		"php": ">=7.3"
 	},
 	"extra": {
@@ -26,11 +26,6 @@
 	"autoload": {
 		"psr-4": {
 			"GeorgRinger\\NumberedPagination\\": "Classes"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"GeorgRinger\\NumberedPagination\\Tests\\": "Tests"
 		}
 	},
 	"replace": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,10 +8,10 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'mail@ringer.it',
     'state' => 'beta',
     'clearCacheOnLoad' => true,
-    'version' => '1.0.2',
+    'version' => '1.0.3',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.12-11.5.99',
+            'typo3' => '9.5.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,17 @@
+<?php
+
+defined('TYPO3_MODE') or die();
+
+if (!class_exists('TYPO3\CMS\Core\Pagination\PaginationInterface')) {
+    class_alias(
+        \GeorgRinger\NumberedPagination\Contract\PaginationInterface::class,
+        'TYPO3\CMS\Core\Pagination\PaginationInterface'
+    );
+}
+
+if (!class_exists('TYPO3\CMS\Core\Pagination\PaginatorInterface')) {
+    class_alias(
+        \GeorgRinger\NumberedPagination\Contract\PaginatorInterface::class,
+        'TYPO3\CMS\Core\Pagination\PaginatorInterface'
+    );
+}


### PR DESCRIPTION
In order to easily backport the new pagination i would like to make the package TYPO3 version independent.
Maybe the usecase sounds weird, but we had one and maybe it is useful for someone else to make the migration path as smooth as possible.