### PR TITLE
Tweak pagination settings

### DIFF
--- a/Classes/NumberedPagination.php
+++ b/Classes/NumberedPagination.php
@@ -141,8 +141,8 @@ final class NumberedPagination implements PaginationInterface
         }
         $this->displayRangeStart = (integer)max($this->displayRangeStart, 1);
         $this->displayRangeEnd = (integer)min($this->displayRangeEnd, $numberOfPages);
-        $this->hasLessPages = $this->displayRangeStart > 2;
-        $this->hasMorePages = $this->displayRangeEnd + 1 < $this->paginator->getNumberOfPages();
+        $this->hasLessPages = $this->displayRangeStart > 1;
+        $this->hasMorePages = $this->displayRangeEnd < $this->paginator->getNumberOfPages();
     }
 
     public function getPaginator(): PaginatorInterface

--- a/Resources/Private/Partials/Pagination.html
+++ b/Resources/Private/Partials/Pagination.html
@@ -1,5 +1,5 @@
 <ul class="f3-widget-paginator">
-    <f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} >= {pagination.firstPageNumber}">
+    <f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} > {pagination.firstPageNumber}">
         <f:then>
             <f:comment>
                 <li class="first">
@@ -32,7 +32,7 @@
     <f:if condition="{pagination.hasMorePages}">
         <li>…</li>
     </f:if>
-    <f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} <= {pagination.lastPageNumber}">
+    <f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} < {pagination.lastPageNumber}">
         <f:then>
             <li class="next">
                 <a href="{f:uri.action(action:actionName, arguments:{currentPage: pagination.nextPageNumber})}" title="{f:translate(key:'pagination.next')}">


### PR DESCRIPTION
This way we get this paginator:

* [1] 2 3 … next
* 1 [2] 3 … next
* prev … 2 [3] 4 … next
* prev … 3 [4] 5
* prev … 3 4 [5]

When 1) uncommenting the `first` and `last` links and 2) commenting out `prev` and `next` it looks like this:

* [1] 2 3 … last
* 1 [2] 3 … last
* first 2 [3] 4 last
* first … 3 [4] 5
* first … 3 4 [5]

When additionally 3) changing their text to `1` and `{pagination.lastPageNumber}` it looks like this:

* [1] 2 3 … 5
* 1 [2] 3 … 5
* 1 2 [3] 4 5
* 1 … 3 [4] 5
* 1 … 3 4 [5]

When 1) uncommenting the `first` and `last` links (renaming them to `|<` and `>|` ) and 2) flipping their position with `prev` and `next` (and renaming them to `<` and `>`) it looks like this:

* [1] 2 3 … > >|
* 1 [2] 3 … > >|
* |< < … 2 [3] 4 … > >|
* |< < …  3 [4] 5
* |< < … 3 4 [5]

Related: #25